### PR TITLE
increasing rstudio autosave frequency

### DIFF
--- a/rstudio-config/rstudio/rstudio-prefs.json
+++ b/rstudio-config/rstudio/rstudio-prefs.json
@@ -5,5 +5,5 @@
     "posix_terminal_shell": "bash",
     "default_project_location": "~",
     "restore_last_project": false,
-    "auto_save_idle_ms": 500
+    "auto_save_idle_ms": 250
 }


### PR DESCRIPTION
@jcanner reported that a student lost their work earlier in the day.  one possible scenario is that they missed the auto-save  window when logging out.  to that end, we'll change the autosave frequency from .5 sec to .25 sec.