### PR TITLE
adding `x` to bash args in postBuild to try and debug .Renviron not appearing

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -exuo pipefail
 
 # installing chromium browser to enable webpdf conversion using nbconvert
 export PLAYWRIGHT_BROWSERS_PATH=${CONDA_DIR}


### PR DESCRIPTION
should hopefully help us resolve https://github.com/cal-icor/csumb-user-image/issues/16
