### PR TITLE
use the full path to .Renviron instead of relative...

### DIFF
--- a/postBuild
+++ b/postBuild
@@ -29,4 +29,4 @@ for x in \
     code-server --extensions-dir ${VSCODE_EXTENSIONS} --install-extension $x
 done
 
-echo "CONDA_DIR=${CONDA_DIR}" >> .Renviron
+echo "CONDA_DIR=${CONDA_DIR}" >> ${HOME}/.Renviron


### PR DESCRIPTION
take two at https://github.com/cal-icor/csumb-user-image/issues/16