### PR TITLE
perma-fixing /srv subdir permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -213,17 +213,15 @@ ENV PATH=${CONDA_DIR}/bin:${R_LIBS_USER}/bin:${DEFAULT_PATH}:/usr/lib/rstudio-se
 # Install IR kernelspec. Requires python and R.
 RUN R -e "IRkernel::installspec(user = FALSE, prefix='${CONDA_DIR}')"
 
-# copy the repo to /srv/repo
-COPY --chown=${NB_USER}:${NB_USER} . ${REPO_DIR}/
-
 # clear out /tmp
 USER root
 RUN rm -rf /tmp/*
 # Remove the pip cache created as part of installing mambaforge
 RUN rm -rf /root/.cache
 
-# RUN chown ${NB_USER}:${NB_USER} /srv/r
-# RUN chown ${NB_USER}:${NB_USER} /srv/conda
+# copy the repo to /srv/repo
+COPY . ${REPO_DIR}/
+
 # RUN chown -R ${NB_USER}:${NB_USER} /srv/shiny-server
 
 USER ${NB_USER}


### PR DESCRIPTION
my fix for https://github.com/cal-icor/csumb-user-image/issues/36 (https://github.com/cal-icor/csumb-user-image/pull/37) was more of a hack than actual fix.  

this should resolve that issue properly.