### PR TITLE
adding tensorflow, pytest and fixing the stupid build

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,9 +11,9 @@ dependencies:
   - ipython==9.7.0
   - jupyter-resource-usage=1.2.0
   - jupyterhub==5.4.3
-  - jupyterlab==4.5
+  - jupyterlab==4.5.1
   - jupyter-archive==3.4.0
-  - jupyter_server==2.16.0
+  - jupyter_server==2.17.0
   - jupyterlab-git==0.51.2
   - jupyterlab_rise==0.43.1
   - jupytext==1.16.6
@@ -21,6 +21,7 @@ dependencies:
   - notebook==7.5.0
   - python==3.11.*
   - pip==25.1.1
+  - sqlite==3.51.1
 
   # r2d installs jupyter-rsession-proxy, but in the base python env, not in the updated one
   - jupyter-rsession-proxy==2.3.0
@@ -38,11 +39,13 @@ dependencies:
   - openpyxl==3.1.5
   - pandas==2.3.0
   - plotly==6.1.2
+  - pytest==9.0.2
   - scikit-learn==1.7.0
   - scipy==1.15.2
   - seaborn==0.13.2
   - statsmodels==0.14.4
   - sympy==1.14.0
+  - tensorflow==2.19.1
 
   # database tooling
   - jupysql==0.11.1


### PR DESCRIPTION
i noticed a few students had installed `tensorflow` and `pytest` in their homedirs, which takes up a lot of space on the nfs mount.

also, when building, i started getting an error on my workstation that stated the jupyter server kernel package couldn't find `sqlite`...  which was stupid, odd, and i couldn't figure out why it just started breaking.  adding `sqlite` in `environment.yml` made it go away tho...