### PR TITLE
bump shared workflows to 0.2.1

### DIFF
--- a/.github/workflows/build-push-create-pr.yaml
+++ b/.github/workflows/build-push-create-pr.yaml
@@ -18,7 +18,7 @@ jobs:
       contents: write
       pull-requests: write
       repository-projects: write
-    uses: cal-icor/shared-workflows/.github/workflows/build-push-create-pr.yaml@0.1.2
+    uses: cal-icor/shared-workflows/.github/workflows/build-push-create-pr.yaml@0.2.1
     with:
       image: ${{ vars.IMAGE}}
       hub: ${{ vars.HUB }}

--- a/.github/workflows/build-test-image.yaml
+++ b/.github/workflows/build-test-image.yaml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   test-build:
-    uses: cal-icor/shared-workflows/.github/workflows/build-test-image.yaml@0.1.1
+    uses: cal-icor/shared-workflows/.github/workflows/build-test-image.yaml@0.2.1


### PR DESCRIPTION
this pulls in the latest repo2docker release

fwiw this image was already using ubuntu 24.04LTS, so this change shouldn't impact anything.  i built/tested this image on my workstation w/the new version