### PR TITLE
bump jupyterlab to 4.5.8

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - ipython==9.14.1
   - jupyter-resource-usage=1.2.0
   - jupyterhub==5.4.4
-  - jupyterlab==4.5.7
+  - jupyterlab==4.5.8
   - jupyter-archive==3.4.0
   - jupyter_server==2.17.0
   - jupyterlab-git==0.51.2


### PR DESCRIPTION
Bumps jupyterlab to 4.5.8.

Tested via repo2docker --no-run on base-python-image — build passed clean.

Generated with Claude Code