### PR TITLE
add R/RStudio functional and browser tests

### DIFF
--- a/.github/workflows/build-push-create-pr.yaml
+++ b/.github/workflows/build-push-create-pr.yaml
@@ -11,6 +11,8 @@ on:
       - 'LICENSE'
       - '.github/**'
       - 'images/**'
+      - 'image-tests/**'
+      - 'browser-tests/**'
 
 jobs:
   build-push-open-pr:
@@ -18,7 +20,7 @@ jobs:
       contents: write
       pull-requests: write
       repository-projects: write
-    uses: cal-icor/shared-workflows/.github/workflows/build-push-create-pr.yaml@0.3.0
+    uses: cal-icor/shared-workflows/.github/workflows/build-push-create-pr.yaml@0.4.0
     with:
       image: ${{ vars.IMAGE}}
       hub: ${{ vars.HUB }}

--- a/.github/workflows/build-test-image.yaml
+++ b/.github/workflows/build-test-image.yaml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   test-build:
-    uses: cal-icor/shared-workflows/.github/workflows/build-test-image.yaml@0.2.1
+    uses: cal-icor/shared-workflows/.github/workflows/build-test-image.yaml@0.4.0

--- a/.github/workflows/yaml-lint.yaml
+++ b/.github/workflows/yaml-lint.yaml
@@ -4,4 +4,4 @@ on:
 
 jobs:
   lint:
-    uses: cal-icor/shared-workflows/.github/workflows/yaml-lint.yaml@0.1.1
+    uses: cal-icor/shared-workflows/.github/workflows/yaml-lint.yaml@0.4.0

--- a/browser-tests/requirements.txt
+++ b/browser-tests/requirements.txt
@@ -1,0 +1,2 @@
+playwright
+pytest-playwright

--- a/browser-tests/test_rstudio.py
+++ b/browser-tests/test_rstudio.py
@@ -1,0 +1,74 @@
+import re
+import pytest
+from playwright.sync_api import Page, expect
+
+JUPYTER_URL = "http://localhost:8888"
+RSTUDIO_URL = f"{JUPYTER_URL}/rstudio/"
+
+# RStudio takes several seconds to start on first proxy hit.
+RSTUDIO_LOAD_TIMEOUT = 60_000   # ms
+CONSOLE_READY_TIMEOUT = 30_000  # ms
+OUTPUT_TIMEOUT = 15_000         # ms
+
+
+@pytest.fixture(scope="session")
+def rstudio_page(browser):
+    """
+    Single browser session shared across all tests.
+    Opens RStudio once and keeps it open so subsequent tests don't
+    pay the rsession startup cost again.
+    """
+    page = browser.new_page()
+    page.goto(RSTUDIO_URL, timeout=RSTUDIO_LOAD_TIMEOUT)
+    page.wait_for_load_state("load", timeout=RSTUDIO_LOAD_TIMEOUT)
+    # Wait for the console output pane to appear, confirming rsession has started.
+    page.wait_for_selector("#rstudio_console_output", timeout=RSTUDIO_LOAD_TIMEOUT)
+    yield page
+    page.close()
+
+
+def _type_in_console(page: Page, code: str):
+    """Click the console ACE editor surface and type a command, then press Enter."""
+    page.locator("#rstudio_console_input .ace_scroller").click()
+    page.keyboard.type(code)
+    page.keyboard.press("Enter")
+
+
+def test_rstudio_page_loads(rstudio_page: Page):
+    """RStudio proxy is reachable and the IDE frame loads."""
+    expect(rstudio_page).to_have_title(
+        re.compile(r"rstudio", re.IGNORECASE),
+        timeout=RSTUDIO_LOAD_TIMEOUT,
+    )
+
+
+def test_rstudio_console_present(rstudio_page: Page):
+    """The R console output pane is visible, confirming rsession started."""
+    expect(rstudio_page.locator("#rstudio_console_output")).to_be_visible(
+        timeout=CONSOLE_READY_TIMEOUT
+    )
+
+
+def test_rstudio_r_version(rstudio_page: Page):
+    """R version shown in the console header matches the pinned version."""
+    expect(rstudio_page.locator("#rstudio_console_interpreter_version")).to_have_text(
+        re.compile(r"R 4\.5\.1"),
+        timeout=CONSOLE_READY_TIMEOUT,
+    )
+
+
+def test_rstudio_library_load(rstudio_page: Page):
+    """tidyverse loads without error in the RStudio console."""
+    _type_in_console(rstudio_page, "library(tidyverse)")
+    rstudio_page.wait_for_timeout(8_000)
+    expect(rstudio_page.locator("#rstudio_console_output")).not_to_contain_text(
+        "Error in library", timeout=OUTPUT_TIMEOUT
+    )
+
+
+def test_rstudio_basic_computation(rstudio_page: Page):
+    """A simple computation runs and returns the expected value."""
+    _type_in_console(rstudio_page, "cat(1 + 1, '\\n')")
+    expect(rstudio_page.locator("#rstudio_console_output")).to_contain_text(
+        "2", timeout=OUTPUT_TIMEOUT
+    )

--- a/image-tests/pytest.ini
+++ b/image-tests/pytest.ini
@@ -1,12 +1,4 @@
 [pytest]
 verbosity_assertions = 2
 verbosity_test_cases = 2
-nb_diff_ignore =
-    /metadata
-    /nbformat
-    /nbformat_minor
-    /cells/*/execution_count
-    /cells/*/metadata
-    /cells/*/outputs/*/execution_count
-
-
+cache_dir = /tmp/pytest_cache

--- a/image-tests/r/test_r_core.R
+++ b/image-tests/r/test_r_core.R
@@ -1,0 +1,90 @@
+#!/usr/bin/env Rscript
+
+# Verify R is the system R, not a conda-installed R.
+# Conda packages like sagemath pull in r-base via rpy2, which shadows
+# /usr/bin/R on PATH and causes version mismatches and broken rsession startup.
+r_home <- R.home()
+if (grepl("conda", r_home, fixed = TRUE)) {
+    stop(paste("R is running from conda, not the system installation:", r_home))
+}
+
+# Verify the pinned R version matches what is in the image spec.
+expected_version <- "4.5.1"
+actual_version <- paste(R.version$major, R.version$minor, sep = ".")
+if (!startsWith(actual_version, expected_version)) {
+    stop(paste("R version mismatch. Expected:", expected_version, "Got:", actual_version))
+}
+
+# IRkernel must be installed for the Jupyter R kernel to work.
+if (!requireNamespace("IRkernel", quietly = TRUE)) {
+    stop("IRkernel is not installed")
+}
+
+packages <- c(
+    "GGally",
+    "Lock5Data",
+    "RColorBrewer",
+    "car",
+    "colorspace",
+    "esquisse",
+    "extrafont",
+    "flexdashboard",
+    "forcats",
+    "forecast",
+    "ggThemeAssist",
+    "ggalluvial",
+    "ggbeeswarm",
+    "ggcorrplot",
+    "ggdist",
+    "ggformula",
+    "gghighlight",
+    "ggmosaic",
+    "ggpubr",
+    "ggrepel",
+    "ggridges",
+    "ggtext",
+    "ggthemes",
+    "gridExtra",
+    "gtsummary",
+    "janitor",
+    "knitr",
+    "leaflet",
+    "lubridate",
+    "mosaic",
+    "naniar",
+    "nycflights13",
+    "openintro",
+    "palmerpenguins",
+    "plotly",
+    "pwr",
+    "rmarkdown",
+    "scales",
+    "see",
+    "sf",
+    "sjPlot",
+    "socviz",
+    "terra",
+    "tidymodels",
+    "tidyr",
+    "tidyverse",
+    "viridis"
+)
+
+for (pkg in packages) {
+    if (!requireNamespace(pkg, quietly = TRUE)) {
+        stop(paste("Package not available:", pkg))
+    }
+    suppressPackageStartupMessages(library(pkg, character.only = TRUE))
+}
+
+# Basic computation: linear model on a built-in dataset.
+data("penguins", package = "palmerpenguins")
+m <- lm(bill_length_mm ~ flipper_length_mm, data = penguins, na.action = na.omit)
+if (length(coef(m)) != 2) {
+    stop("lm() returned unexpected number of coefficients")
+}
+if (any(is.na(coef(m)))) {
+    stop("lm() coefficients contain NA")
+}
+
+cat("R core tests passed\n")

--- a/image-tests/r/test_r_csumb.R
+++ b/image-tests/r/test_r_csumb.R
@@ -1,0 +1,22 @@
+#!/usr/bin/env Rscript
+
+# CSUMB-specific R packages not present in base-user-image.
+packages <- c(
+    "BSDA",
+    "DescTools",
+    "reticulate",
+    "pbdZMQ",
+    "sweep",
+    "tidyquant",
+    "tidyverse",
+    "timetk"
+)
+
+for (pkg in packages) {
+    if (!requireNamespace(pkg, quietly = TRUE)) {
+        stop(paste("Package not available:", pkg))
+    }
+    suppressPackageStartupMessages(library(pkg, character.only = TRUE))
+}
+
+cat("R CSUMB-specific tests passed\n")

--- a/image-tests/test_r.py
+++ b/image-tests/test_r.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+import subprocess
+import sys
+from pathlib import Path
+
+_R_DIR = Path("image-tests/r")
+
+
+def _run_rscript(script_path):
+    result = subprocess.run(
+        ["Rscript", str(script_path)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        print(result.stdout)
+        print(result.stderr, file=sys.stderr)
+    return result
+
+
+def test_r_core():
+    result = _run_rscript(_R_DIR / "test_r_core.R")
+    assert result.returncode == 0, f"R core tests failed:\n{result.stderr}"
+    assert "R core tests passed" in result.stdout
+
+
+def test_r_csumb():
+    result = _run_rscript(_R_DIR / "test_r_csumb.R")
+    assert result.returncode == 0, f"R CSUMB-specific tests failed:\n{result.stderr}"
+    assert "R CSUMB-specific tests passed" in result.stdout


### PR DESCRIPTION
## Summary

- Adds two test layers for R/RStudio regressions: Rscript-based functional tests inside the container and Playwright browser tests against a live RStudio server
- Bumps shared-workflows references to @0.4.0
- Adds `image-tests/**` and `browser-tests/**` to `paths-ignore` in the build-push workflow so test-only merges to main do not trigger an image push and hub deployment PR

## Background

PR #87 reverted a sage installation that broke RStudio. The root cause: sage pulls in rpy2, which depends on r-base. The conda r-base package placed a second R at `/srv/conda/bin/R`, which appeared before `/usr/bin/R` on PATH. `jupyter-rsession-proxy` uses PATH to find R when setting up the rsession environment, so it picked up the wrong `R_HOME` and RStudio launched with the wrong R version and missing packages.

These tests catch that failure mode and similar PATH-shadowing issues before they reach production.

## Functional tests (image-tests/)

Tests run inside the container via the repo2docker-action test mechanism. The action runs:

```
docker run -u 1000 -w /srv/repo <image> /bin/bash -c 'pip install -r image-tests/requirements.txt; py.test image-tests/'
```

`image-tests/test_r.py` is a pytest wrapper that calls Rscript on each R script and asserts on exit code and a stdout sentinel string. It runs both `test_r_core.R` (shared with base-user-image) and `test_r_csumb.R` (CSUMB-specific packages).

`image-tests/r/test_r_core.R` checks:
- `R.home()` does not contain "conda" (direct detection of the PATH-shadowing bug from #85)
- R version matches the pinned version (4.5.1)
- IRkernel is installed
- All core R packages load without error (~45 packages including tidyverse, ggplot2, sf, palmerpenguins, tidymodels)
- A basic `lm()` call on the penguins dataset returns valid, non-NA coefficients

`image-tests/r/test_r_csumb.R` verifies that CSUMB-specific packages load without error: BSDA, DescTools, reticulate, pbdZMQ, sweep, tidyquant, tidyverse, timetk.

`image-tests/pytest.ini` sets `cache_dir` to `/tmp/pytest_cache` so tests running as uid 1000 do not hit permission errors writing to `/srv/repo`. It also removes leftover pytest-notebook config that produced unknown-config warnings.

## Browser tests (browser-tests/)

Five Playwright/Chromium tests run outside the container against the live JupyterLab server started by the CI workflow. The shared workflow (cal-icor/shared-workflows#12) handles starting the container, waiting for Jupyter, installing Playwright, running pytest, and stopping the container.

`browser-tests/test_rstudio.py` tests:
- `test_rstudio_page_loads`: RStudio proxy is reachable and the IDE frame loads
- `test_rstudio_console_present`: R console output pane is visible, confirming rsession started
- `test_rstudio_r_version`: version string in the console header matches R 4.5.1. This catches conda R shadowing at the UI level.
- `test_rstudio_library_load`: `library(tidyverse)` loads without error
- `test_rstudio_basic_computation`: `cat(1 + 1)` prints 2

Two implementation notes: `networkidle` is not used for page load detection because RStudio keeps persistent WebSocket connections open and `networkidle` never fires. Instead the tests use `wait_for_load_state("load")` followed by `wait_for_selector("#rstudio_console_output")`. Console input clicks target `.ace_scroller` rather than the hidden textarea, because `.ace_content` intercepts pointer events over the textarea.

## Timing

Total added CI overhead: roughly 50-60 seconds per run.

| Step | Expected duration |
|---|---|
| Check for browser tests | ~1s |
| Start container | ~2s |
| Wait for Jupyter | 5-10s |
| Install Playwright + run tests | 30-45s |
| Stop container | ~2s |

## Workflow changes

All three workflow files are bumped to @0.4.0.

`build-push-create-pr.yaml` gains `image-tests/**` and `browser-tests/**` in `paths-ignore`. Test-only changes merged to main will not trigger a new image build, push, or hub deployment PR.

## Test plan

- [ ] Confirm functional tests pass inside the container (`test_r_core.R` passes, `R.home()` does not contain "conda")
- [ ] Confirm `test_r_csumb.R` passes (all CSUMB-specific packages load)
- [ ] Confirm browser tests pass: all five tests green, R 4.5.1 shown in console
- [ ] Confirm a test-only merge to main does not trigger the build-push workflow
- [ ] Confirm a PR with no `browser-tests/` directory skips all browser test steps

## Notes

This PR depends on cal-icor/shared-workflows#12 being merged and tagged at 0.4.0 first. The workflow references will fail until that tag exists.