### PR TITLE
Update ipython and add ipykernel in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,8 @@ dependencies:
   - attrs==26.1.0
   - gh-scoped-creds==4.1
   - git==2.54.0
-  - ipython==9.14.1
+  - ipykernel==7.3.0
+  - ipython==9.15.0
   - jupyter-resource-usage=1.2.1
   # pinned to match the deployed hub image's jupyterhub version
   - jupyterhub==5.5.0


### PR DESCRIPTION
The older versions ran each notebook cell in a cleared context, which resets numpy 2 print options for cell.

The problem surfaced when using datascience and numpy packages in the same notebook. The clearing of context cleared datascience's np.set_printoptions(legacy='1.13') which set up numpy to start using it's latest print options (e.g. np.True_) and consequently broke our tests when we use otter grade.

The newer versions no longer reset per-cell, so datascience's legacy setting persists and notebook output matches what autograder seeds expect and consequently CI will match the grading servers behavior