### PR TITLE
dont auto-load or auto-save rdata for new sessions

### DIFF
--- a/rstudio-prefs.json
+++ b/rstudio-prefs.json
@@ -7,5 +7,7 @@
     "default_project_location": "~",
     "restore_last_project": false,
     "auto_save_idle_ms": 500,
-    "copilot-enabled": 0
+    "copilot-enabled": 0,
+    "save_workspace": "never",
+    "load_workspace": false
 }


### PR DESCRIPTION
after meeting w/robin donatello (chico state), she asked for these default settings to be loaded as projects were bringing in the incorrect settings for workspaces.

```
    "save_workspace": "never",
    "load_workspace": false
```

@alanaunfried @jcanner is this something that you two can work with?  this image is shared across a couple of different deployments and i'm just making sure that there's no unintended blast radius from this change.